### PR TITLE
Support aarch64

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,10 +13,151 @@ on:
   pull_request:
 
 env:
+  REDBPF_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/redbpf-build
   IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/foniod-build
   MAIN_BRANCH: main
 
 jobs:
+  redbpf-buildx-aarch64-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          buildkitd-flags: --debug
+      -
+        name: Inspect builder
+        run: |
+          echo "Name:      ${{ steps.buildx.outputs.name }}"
+          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
+          echo "Status:    ${{ steps.buildx.outputs.status }}"
+          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
+          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
+      -
+        name: Set up version information
+        run: |
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          [ "$VERSION" == "$MAIN_BRANCH" ] && VERSION=latest
+          echo "version=$VERSION" >> $GITHUB_ENV
+      -
+        name: Build aarch64 Debian11 for RedBPF
+        id: aarch64-debian11
+        run: |
+          VERSION=${{ env.version }}-aarch64-debian11
+          docker buildx build -f redbpf/Dockerfile.debian11 --platform linux/arm64 \
+          -t $REDBPF_IMAGE_NAME:$VERSION --load ./redbpf
+          echo "::set-output name=image_id::$REDBPF_IMAGE_NAME:$VERSION"
+      -
+        name: Build aarch64 Fedora35 for RedBPF
+        id: aarch64-fedora35
+        run: |
+          VERSION=${{ env.version }}-aarch64-fedora35
+          docker buildx build -f redbpf/Dockerfile.fedora35 --platform linux/arm64 \
+          -t $REDBPF_IMAGE_NAME:$VERSION --load ./redbpf
+          echo "::set-output name=image_id::$REDBPF_IMAGE_NAME:$VERSION"
+      -
+        name: Build aarch64 Ubuntu21.04 for RedBPF
+        id: aarch64-ubuntu2104
+        run: |
+          VERSION=${{ env.version }}-aarch64-ubuntu21.04
+          docker buildx build -f redbpf/Dockerfile.ubuntu21.04 --platform linux/arm64 \
+          -t $REDBPF_IMAGE_NAME:$VERSION --load ./redbpf
+          echo "::set-output name=image_id::$REDBPF_IMAGE_NAME:$VERSION"
+      -
+        name: Build aarch64 alpine3.15 for RedBPF
+        id: aarch64-alpine315
+        run: |
+          VERSION=${{ env.version }}-aarch64-alpine3.15
+          docker buildx build -f redbpf/Dockerfile.alpine3.15 --platform linux/arm64 \
+          -t $REDBPF_IMAGE_NAME:$VERSION --load ./redbpf
+          echo "::set-output name=image_id::$REDBPF_IMAGE_NAME:$VERSION"
+      -
+        name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      -
+        name: Push image
+        if: github.event_name == 'push'
+        run: |
+          docker push ${{ steps.aarch64-debian11.outputs.image_id }}
+          docker push ${{ steps.aarch64-fedora35.outputs.image_id }}
+          docker push ${{ steps.aarch64-ubuntu2104.outputs.image_id }}
+          docker push ${{ steps.aarch64-alpine315.outputs.image_id }}
+
+  redbpf-build-x86_64-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up version information
+        run: |
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          [ "$VERSION" == "$MAIN_BRANCH" ] && VERSION=latest
+          echo "version=$VERSION" >> $GITHUB_ENV
+      -
+        name: Build x86_64 Debian11 for RedBPF
+        id: x86_64-debian11
+        run: |
+          VERSION=${{ env.version }}-x86_64-debian11
+          docker build -f redbpf/Dockerfile.debian11 \
+          -t $REDBPF_IMAGE_NAME:$VERSION ./redbpf
+          echo "::set-output name=image_id::$REDBPF_IMAGE_NAME:$VERSION"
+      -
+        name: Build x86_64 Fedora35 for RedBPF
+        id: x86_64-fedora35
+        run: |
+          VERSION=${{ env.version }}-x86_64-fedora35
+          docker build -f redbpf/Dockerfile.fedora35 \
+          -t $REDBPF_IMAGE_NAME:$VERSION ./redbpf
+          echo "::set-output name=image_id::$REDBPF_IMAGE_NAME:$VERSION"
+      -
+        name: Build x86_64 Ubuntu21.04 for RedBPF
+        id: x86_64-ubuntu2104
+        run: |
+          VERSION=${{ env.version }}-x86_64-ubuntu21.04
+          docker build -f redbpf/Dockerfile.ubuntu21.04 \
+          -t $REDBPF_IMAGE_NAME:$VERSION ./redbpf
+          echo "::set-output name=image_id::$REDBPF_IMAGE_NAME:$VERSION"
+      -
+        name: Build x86_64 alpine3.15 for RedBPF
+        id: x86_64-alpine315
+        run: |
+          VERSION=${{ env.version }}-x86_64-alpine3.15
+          docker build -f redbpf/Dockerfile.alpine3.15 \
+          -t $REDBPF_IMAGE_NAME:$VERSION ./redbpf
+          echo "::set-output name=image_id::$REDBPF_IMAGE_NAME:$VERSION"
+      -
+        name: Build x86_64 archlinux for RedBPF
+        id: x86_64-archlinux
+        run: |
+          VERSION=${{ env.version }}-x86_64-archlinux
+          docker build -f redbpf/Dockerfile.archlinux \
+          -t $REDBPF_IMAGE_NAME:$VERSION ./redbpf
+          echo "::set-output name=image_id::$REDBPF_IMAGE_NAME:$VERSION"
+      -
+        name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      -
+        name: Push image
+        if: github.event_name == 'push'
+        run: |
+          docker push ${{ steps.x86_64-debian11.outputs.image_id }}
+          docker push ${{ steps.x86_64-fedora35.outputs.image_id }}
+          docker push ${{ steps.x86_64-ubuntu2104.outputs.image_id }}
+          docker push ${{ steps.x86_64-alpine315.outputs.image_id }}
+          docker push ${{ steps.x86_64-archlinux.outputs.image_id }}
+
   build-and-push:
     runs-on: ubuntu-latest
     steps:

--- a/redbpf/Dockerfile.alpine3.15
+++ b/redbpf/Dockerfile.alpine3.15
@@ -1,0 +1,39 @@
+FROM alpine:3.15
+
+ARG TARGETPLATFORM
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+
+RUN apk add --no-cache \
+    curl \
+    linux-headers \
+    build-base \
+    make \
+    libxml2-dev \
+    linux-lts-dev \
+    linux-lts \
+    clang-libs \
+    llvm12 \
+    llvm12-libs \
+    llvm12-dev \
+    llvm12-static
+
+RUN llvm-config --version | grep -q '^12'
+
+# RedBPF depends on LLVM12 by default and Rust v1.52~v1.55 uses LLVM12
+# cf) RedBPF can rely on LLVM13 and Rust v1.56~ uses LLVM13
+RUN curl https://sh.rustup.rs -sSf > rustup.sh \
+    && sh rustup.sh -y \
+          --default-toolchain 1.55 \
+          --profile minimal \
+          --no-modify-path \
+    && rm -f rustup.sh \
+    && rustup component add rustfmt \
+    && rustup --version \
+    && cargo -vV \
+    && rustc -vV
+
+# Can not extract vmlinux or btf from the vmlinuz image.
+
+WORKDIR /build

--- a/redbpf/Dockerfile.archlinux
+++ b/redbpf/Dockerfile.archlinux
@@ -1,0 +1,34 @@
+FROM archlinux:latest
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+
+RUN pacman --noconfirm -Syu \
+    && pacman -S --noconfirm \
+    llvm \
+    llvm-libs \
+    libffi \
+    clang \
+    make \
+    linux-headers \
+    linux
+
+RUN llvm-config --version | grep -q '^13'
+
+# RedBPF can rely on LLVM13 and Rust v1.56~ uses LLVM13
+RUN curl https://sh.rustup.rs -sSf > rustup.sh \
+    && sh rustup.sh -y \
+          --default-toolchain 1.57 \
+          --profile minimal \
+          --no-modify-path \
+    && rm -f rustup.sh \
+    && rustup component add rustfmt \
+    && rustup --version \
+    && cargo -vV \
+    && rustc -vV
+
+RUN /lib/modules/*/build/scripts/extract-vmlinux /boot/vmlinuz-linux > /boot/vmlinux
+# archlinux does not support arm64 for docker images as of now Dec. 2021.
+
+WORKDIR /build

--- a/redbpf/Dockerfile.debian11
+++ b/redbpf/Dockerfile.debian11
@@ -1,0 +1,51 @@
+FROM debian:11
+
+ARG TARGETPLATFORM
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get -y install \
+    curl \
+    wget \
+    lsb-release \
+    libelf-dev \
+    build-essential \
+    linux-headers-generic \
+    software-properties-common \
+    gnupg2 \
+    && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 12 && rm -f ./llvm.sh \
+    && apt-get -y install "linux-image-$(ls /lib/modules)" \
+    && apt-get clean -y
+
+RUN ln -s /usr/bin/llvm-config-12 /usr/bin/llvm-config
+RUN llvm-config --version | grep -q '^12'
+
+# RedBPF depends on LLVM12 by default and Rust v1.52~v1.55 uses LLVM12
+# cf) RedBPF can rely on LLVM13 and Rust v1.56~ uses LLVM13
+RUN curl https://sh.rustup.rs -sSf > rustup.sh \
+    && sh rustup.sh -y \
+          --default-toolchain 1.55 \
+          --profile minimal \
+          --no-modify-path \
+    && rm -f rustup.sh \
+    && rustup component add rustfmt \
+    && rustup --version \
+    && cargo -vV \
+    && rustc -vV
+
+COPY extract-btf-aarch64.rs .
+
+RUN if [ $TARGETPLATFORM = "linux/arm64" ]; then \
+      rustc extract-btf-aarch64.rs \
+      && ./extract-btf-aarch64 /boot/vmlinuz-* /boot/vmlinux-btf; \
+    else \
+      wget https://raw.githubusercontent.com/torvalds/linux/master/scripts/extract-vmlinux \
+      && sh extract-vmlinux /boot/vmlinuz-* > /boot/vmlinux \
+      && rm -f extract-vmlinux; \
+    fi
+RUN rm -f extract-btf-aarch64.rs
+
+WORKDIR /build

--- a/redbpf/Dockerfile.fedora35
+++ b/redbpf/Dockerfile.fedora35
@@ -35,7 +35,7 @@ COPY extract-btf-aarch64.rs .
 
 RUN if [ $TARGETPLATFORM = "linux/arm64" ]; then \
       rustc extract-btf-aarch64.rs \
-      && ./extract-btf-aarch64 /lib/modules/*/vmlinuz /boot/vmlinux-btf; \
+      && gzip -dc /lib/modules/*/vmlinuz | ./extract-btf-aarch64 /dev/stdin /boot/vmlinux-btf; \
     else \
       /lib/modules/*/build/scripts/extract-vmlinux /lib/modules/*/vmlinuz > /boot/vmlinux; \
     fi

--- a/redbpf/Dockerfile.fedora35
+++ b/redbpf/Dockerfile.fedora35
@@ -1,0 +1,44 @@
+FROM fedora:35
+
+ARG TARGETPLATFORM
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+
+RUN dnf install -y \
+    clang-13.0.0 \
+	llvm-13.0.0 \
+	llvm-libs-13.0.0 \
+	llvm-devel-13.0.0 \
+	llvm-static-13.0.0 \
+	kernel \
+	kernel-devel \
+	elfutils-libelf-devel \
+	make \
+    zstd
+
+RUN llvm-config --version | grep -q '^13'
+
+# RedBPF can rely on LLVM13 and Rust v1.56~ uses LLVM13
+RUN curl https://sh.rustup.rs -sSf > rustup.sh \
+    && sh rustup.sh -y \
+          --default-toolchain 1.57 \
+          --profile minimal \
+          --no-modify-path \
+    && rm -f rustup.sh \
+    && rustup component add rustfmt \
+    && rustup --version \
+    && cargo -vV \
+    && rustc -vV
+
+COPY extract-btf-aarch64.rs .
+
+RUN if [ $TARGETPLATFORM = "linux/arm64" ]; then \
+      rustc extract-btf-aarch64.rs \
+      && ./extract-btf-aarch64 /lib/modules/*/vmlinuz /boot/vmlinux-btf; \
+    else \
+      /lib/modules/*/build/scripts/extract-vmlinux /lib/modules/*/vmlinuz > /boot/vmlinux; \
+    fi
+RUN rm -f extract-btf-aarch64.rs
+
+WORKDIR /build

--- a/redbpf/Dockerfile.ubuntu21.04
+++ b/redbpf/Dockerfile.ubuntu21.04
@@ -1,0 +1,48 @@
+FROM ubuntu:21.04
+
+ARG TARGETPLATFORM
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get -y install \
+    curl \
+    build-essential \
+    libllvm12 \
+    llvm-12-dev \
+    libclang-12-dev \
+    libelf-dev \
+    linux-headers-generic
+RUN apt-get -y install \
+    "linux-image-$(ls /lib/modules)" \
+    && apt-get clean -y
+
+RUN ln -s /usr/bin/llvm-config-12 /usr/bin/llvm-config
+RUN llvm-config --version | grep -q '^12'
+
+# RedBPF depends on LLVM12 by default and Rust v1.52~v1.55 uses LLVM12
+# cf) RedBPF can rely on LLVM13 and Rust v1.56~ uses LLVM13
+RUN curl https://sh.rustup.rs -sSf > rustup.sh \
+    && sh rustup.sh -y \
+          --default-toolchain 1.55 \
+          --profile minimal \
+          --no-modify-path \
+    && rm -f rustup.sh \
+    && rustup component add rustfmt \
+    && rustup --version \
+    && cargo -vV \
+    && rustc -vV
+
+COPY extract-btf-aarch64.rs .
+
+RUN if [ $TARGETPLATFORM = "linux/arm64" ]; then \
+      rustc extract-btf-aarch64.rs \
+      && gzip -dc /boot/vmlinuz | ./extract-btf-aarch64 /dev/stdin /boot/vmlinux-btf; \
+    else \
+      /lib/modules/*/build/scripts/extract-vmlinux /boot/vmlinuz > /boot/vmlinux; \
+    fi
+RUN rm -f extract-btf-aarch64.rs
+
+WORKDIR /build

--- a/redbpf/extract-btf-aarch64.rs
+++ b/redbpf/extract-btf-aarch64.rs
@@ -1,0 +1,44 @@
+//! Extract content of the BTF section data from vmlinuz of aarch64
+//! architecture. Note that the extract-vmlinux script that is located in the
+//! kernel source works correctly only if vmlinuz is built for x86_64
+//! architecture.
+use std::{env, fs, ptr};
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct btf_header {
+    pub magic: u16,
+    pub version: u8,
+    pub flags: u8,
+    pub hdr_len: u32,
+    pub type_off: u32,
+    pub type_len: u32,
+    pub str_off: u32,
+    pub str_len: u32,
+}
+
+fn main() {
+    let args = env::args().collect::<Vec<String>>();
+    if args.len() != 3 {
+        eprintln!("error: specify vmlinuz of aarch64");
+        return;
+    }
+
+    let vmlinux = &args[1];
+    let bytes = fs::read(vmlinux).expect("failed to read given file");
+    let patt = [
+        /* magic */ 0x9f, 0xeb, /* version */ 0x01, /* flags */ 0x00,
+        /* hdr_len */ 0x18, 0x00, 0x00, 0x00,
+    ];
+    let pos = bytes
+        .as_slice()
+        .windows(patt.len())
+        .position(|win| win == patt)
+        .expect("btf header not found");
+    let btf_hdr = unsafe { ptr::read_unaligned(bytes.as_ptr().add(pos) as *const btf_header) };
+    let start = pos;
+    let end = start + (btf_hdr.hdr_len + btf_hdr.str_off + btf_hdr.str_len) as usize;
+    let btf_bytes = &bytes[start..end];
+    let output = &args[2];
+    fs::write(output, btf_bytes).expect("failed to write btf data");
+}


### PR DESCRIPTION
Build x86_64 and aarch64 architecture docker images for RedBPF.
New Dockerfiles specify specific LLVM versions and Rust versions that match well.

These docker images will be used to test RedBPF compilation of new PR.
This PR is a part of solutions that resolve this issue in RedBPF https://github.com/foniod/redbpf/issues/239
