### PR TITLE
Fix rust version to 1.55

### DIFF
--- a/Dockerfile.18.04
+++ b/Dockerfile.18.04
@@ -34,7 +34,7 @@ RUN rm -rf /tmp/kernel
 
 RUN curl https://sh.rustup.rs -sSf > rustup.sh \
     && sh rustup.sh -y \
-          --default-toolchain stable \
+          --default-toolchain 1.55 \
           --profile minimal \
           --no-modify-path \
     && rustup component add rustfmt \

--- a/Dockerfile.20.04
+++ b/Dockerfile.20.04
@@ -22,7 +22,7 @@ RUN apt-get update \
 
 RUN curl https://sh.rustup.rs -sSf > rustup.sh \
     && sh rustup.sh -y \
-          --default-toolchain stable \
+          --default-toolchain 1.55 \
           --profile minimal \
           --no-modify-path \
     && rustup component add rustfmt \

--- a/Dockerfile.21.04
+++ b/Dockerfile.21.04
@@ -23,7 +23,7 @@ RUN apt-get -y install "linux-image-$(ls /lib/modules)"
 
 RUN curl https://sh.rustup.rs -sSf > rustup.sh \
     && sh rustup.sh -y \
-          --default-toolchain stable \
+          --default-toolchain 1.55 \
           --profile minimal \
           --no-modify-path \
     && rustup component add rustfmt \

--- a/Dockerfile.fedora-34
+++ b/Dockerfile.fedora-34
@@ -24,7 +24,7 @@ RUN dnf install -y clang-12.0.0 \
 
 RUN curl https://sh.rustup.rs -sSf > rustup.sh \
     && sh rustup.sh -y \
-          --default-toolchain stable \
+          --default-toolchain 1.55 \
           --profile minimal \
           --no-modify-path \
     && rustup component add rustfmt \


### PR DESCRIPTION
Fix foniod build images
- latest-ubuntu-18.04
- latest-ubuntu-20.04
- latest-ubuntu-21.04
- latest-fedora-34

Since rustup installs the latest stable rust, it is failed to build RedBPF with LLVM12. LLVM12 can not be used with recent rust versions.