### PR TITLE
Use stable rust

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -73,6 +73,22 @@ jobs:
           -t $REDBPF_IMAGE_NAME:$VERSION --load ./redbpf
           echo "::set-output name=image_id::$REDBPF_IMAGE_NAME:$VERSION"
       -
+        name: Build aarch64 Ubuntu20.04 LTS for RedBPF
+        id: aarch64-ubuntu2004
+        run: |
+          VERSION=${{ env.version }}-aarch64-ubuntu20.04
+          docker buildx build -f redbpf/Dockerfile.ubuntu20.04 --platform linux/arm64 \
+          -t $REDBPF_IMAGE_NAME:$VERSION --load ./redbpf
+          echo "::set-output name=image_id::$REDBPF_IMAGE_NAME:$VERSION"
+      -
+        name: Build aarch64 Ubuntu18.04 LTS for RedBPF
+        id: aarch64-ubuntu1804
+        run: |
+          VERSION=${{ env.version }}-aarch64-ubuntu18.04
+          docker buildx build -f redbpf/Dockerfile.ubuntu18.04 --platform linux/arm64 \
+          -t $REDBPF_IMAGE_NAME:$VERSION --load ./redbpf
+          echo "::set-output name=image_id::$REDBPF_IMAGE_NAME:$VERSION"
+      -
         name: Build aarch64 alpine3.15 for RedBPF
         id: aarch64-alpine315
         run: |
@@ -90,6 +106,8 @@ jobs:
           docker push ${{ steps.aarch64-debian11.outputs.image_id }}
           docker push ${{ steps.aarch64-fedora35.outputs.image_id }}
           docker push ${{ steps.aarch64-ubuntu2104.outputs.image_id }}
+          docker push ${{ steps.aarch64-ubuntu2004.outputs.image_id }}
+          docker push ${{ steps.aarch64-ubuntu1804.outputs.image_id }}
           docker push ${{ steps.aarch64-alpine315.outputs.image_id }}
 
   redbpf-build-x86_64-and-push:
@@ -130,6 +148,22 @@ jobs:
           -t $REDBPF_IMAGE_NAME:$VERSION ./redbpf
           echo "::set-output name=image_id::$REDBPF_IMAGE_NAME:$VERSION"
       -
+        name: Build x86_64 Ubuntu20.04 LTS for RedBPF
+        id: x86_64-ubuntu2004
+        run: |
+          VERSION=${{ env.version }}-x86_64-ubuntu20.04
+          docker build -f redbpf/Dockerfile.ubuntu20.04 \
+          -t $REDBPF_IMAGE_NAME:$VERSION ./redbpf
+          echo "::set-output name=image_id::$REDBPF_IMAGE_NAME:$VERSION"
+      -
+        name: Build x86_64 Ubuntu18.04 LTS for RedBPF
+        id: x86_64-ubuntu1804
+        run: |
+          VERSION=${{ env.version }}-x86_64-ubuntu18.04
+          docker build -f redbpf/Dockerfile.ubuntu18.04 \
+          -t $REDBPF_IMAGE_NAME:$VERSION ./redbpf
+          echo "::set-output name=image_id::$REDBPF_IMAGE_NAME:$VERSION"
+      -
         name: Build x86_64 alpine3.15 for RedBPF
         id: x86_64-alpine315
         run: |
@@ -155,6 +189,8 @@ jobs:
           docker push ${{ steps.x86_64-debian11.outputs.image_id }}
           docker push ${{ steps.x86_64-fedora35.outputs.image_id }}
           docker push ${{ steps.x86_64-ubuntu2104.outputs.image_id }}
+          docker push ${{ steps.x86_64-ubuntu2004.outputs.image_id }}
+          docker push ${{ steps.x86_64-ubuntu1804.outputs.image_id }}
           docker push ${{ steps.x86_64-alpine315.outputs.image_id }}
           docker push ${{ steps.x86_64-archlinux.outputs.image_id }}
 

--- a/redbpf/Dockerfile.alpine3.15
+++ b/redbpf/Dockerfile.alpine3.15
@@ -21,8 +21,7 @@ RUN apk add --no-cache \
 
 RUN llvm-config --version | grep -q '^12'
 
-# RedBPF depends on LLVM12 by default and Rust v1.52~v1.55 uses LLVM12
-# cf) RedBPF can rely on LLVM13 and Rust v1.56~ uses LLVM13
+# Alpine 3.15 only supports LLVM 12 so fix Rust 1.55
 RUN curl https://sh.rustup.rs -sSf > rustup.sh \
     && sh rustup.sh -y \
           --default-toolchain 1.55 \

--- a/redbpf/Dockerfile.archlinux
+++ b/redbpf/Dockerfile.archlinux
@@ -16,10 +16,11 @@ RUN pacman --noconfirm -Syu \
 
 RUN llvm-config --version | grep -q '^13'
 
-# RedBPF can rely on LLVM13 and Rust v1.56~ uses LLVM13
+# Install current stable Rust. The first goal of RedBPF build test is to
+# support latest Rust release.
 RUN curl https://sh.rustup.rs -sSf > rustup.sh \
     && sh rustup.sh -y \
-          --default-toolchain 1.57 \
+          --default-toolchain stable \
           --profile minimal \
           --no-modify-path \
     && rm -f rustup.sh \

--- a/redbpf/Dockerfile.debian11
+++ b/redbpf/Dockerfile.debian11
@@ -16,18 +16,18 @@ RUN apt-get update \
     linux-headers-generic \
     software-properties-common \
     gnupg2 \
-    && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 12 && rm -f ./llvm.sh \
+    && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 13 && rm -f ./llvm.sh \
     && apt-get -y install "linux-image-$(ls /lib/modules)" \
     && apt-get clean -y
 
-RUN ln -s /usr/bin/llvm-config-12 /usr/bin/llvm-config
-RUN llvm-config --version | grep -q '^12'
+RUN ln -s /usr/bin/llvm-config-13 /usr/bin/llvm-config
+RUN llvm-config --version | grep -q '^13'
 
-# RedBPF depends on LLVM12 by default and Rust v1.52~v1.55 uses LLVM12
-# cf) RedBPF can rely on LLVM13 and Rust v1.56~ uses LLVM13
+# Install current stable Rust. The first goal of RedBPF build test is to
+# support latest Rust release.
 RUN curl https://sh.rustup.rs -sSf > rustup.sh \
     && sh rustup.sh -y \
-          --default-toolchain 1.55 \
+          --default-toolchain stable \
           --profile minimal \
           --no-modify-path \
     && rm -f rustup.sh \
@@ -38,7 +38,7 @@ RUN curl https://sh.rustup.rs -sSf > rustup.sh \
 
 COPY extract-btf-aarch64.rs .
 
-RUN if [ $TARGETPLATFORM = "linux/arm64" ]; then \
+RUN if [ x$TARGETPLATFORM = x"linux/arm64" ]; then \
       rustc extract-btf-aarch64.rs \
       && ./extract-btf-aarch64 /boot/vmlinuz-* /boot/vmlinux-btf; \
     else \

--- a/redbpf/Dockerfile.fedora35
+++ b/redbpf/Dockerfile.fedora35
@@ -19,10 +19,11 @@ RUN dnf install -y \
 
 RUN llvm-config --version | grep -q '^13'
 
-# RedBPF can rely on LLVM13 and Rust v1.56~ uses LLVM13
+# Install current stable Rust. The first goal of RedBPF build test is to
+# support latest Rust release.
 RUN curl https://sh.rustup.rs -sSf > rustup.sh \
     && sh rustup.sh -y \
-          --default-toolchain 1.57 \
+          --default-toolchain stable \
           --profile minimal \
           --no-modify-path \
     && rm -f rustup.sh \
@@ -33,7 +34,7 @@ RUN curl https://sh.rustup.rs -sSf > rustup.sh \
 
 COPY extract-btf-aarch64.rs .
 
-RUN if [ $TARGETPLATFORM = "linux/arm64" ]; then \
+RUN if [ x$TARGETPLATFORM = x"linux/arm64" ]; then \
       rustc extract-btf-aarch64.rs \
       && gzip -dc /lib/modules/*/vmlinuz | ./extract-btf-aarch64 /dev/stdin /boot/vmlinux-btf; \
     else \

--- a/redbpf/Dockerfile.ubuntu18.04
+++ b/redbpf/Dockerfile.ubuntu18.04
@@ -1,0 +1,59 @@
+FROM ubuntu:18.04
+
+ARG TARGETPLATFORM
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get -y install \
+    curl \
+    wget \
+    build-essential \
+    software-properties-common \
+    lsb-release \
+    libelf-dev \
+    linux-base \
+    libkmod2 \
+    kmod \
+    && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 13 && rm -f ./llvm.sh
+
+RUN ln -s /usr/bin/llvm-config-13 /usr/bin/llvm-config
+RUN llvm-config --version | grep -q '^13'
+
+# Install kernel v4.19 to check the oldest supported kernel
+WORKDIR /tmp/kernel
+RUN if [ x$TARGETPLATFORM = x"linux/arm64" ]; then \
+      wget \
+      https://kernel.ubuntu.com/~kernel-ppa/mainline/v4.19.5/linux-headers-4.19.5-041905-generic_4.19.5-041905.201812031110_arm64.deb \
+      https://kernel.ubuntu.com/~kernel-ppa/mainline/v4.19.5/linux-image-4.19.5-041905-generic_4.19.5-041905.201812031110_arm64.deb \
+      https://kernel.ubuntu.com/~kernel-ppa/mainline/v4.19.5/linux-modules-4.19.5-041905-generic_4.19.5-041905.201812031110_arm64.deb \
+      https://kernel.ubuntu.com/~kernel-ppa/mainline/v4.19.5/linux-headers-4.19.5-041905_4.19.5-041905.201812031110_all.deb; \
+    else \
+      wget \
+      https://kernel.ubuntu.com/~kernel-ppa/mainline/v4.19.5/linux-headers-4.19.5-041905-generic_4.19.5-041905.201812031110_amd64.deb \
+      https://kernel.ubuntu.com/~kernel-ppa/mainline/v4.19.5/linux-image-unsigned-4.19.5-041905-generic_4.19.5-041905.201812031110_amd64.deb \
+      https://kernel.ubuntu.com/~kernel-ppa/mainline/v4.19.5/linux-modules-4.19.5-041905-generic_4.19.5-041905.201812031110_amd64.deb \
+      https://kernel.ubuntu.com/~kernel-ppa/mainline/v4.19.5/linux-headers-4.19.5-041905_4.19.5-041905.201812031110_all.deb; \
+    fi; \
+    dpkg -i linux-*4.19.5*.deb
+WORKDIR /
+RUN rm -rf /tmp/kernel
+
+# Install current stable Rust. The first goal of RedBPF build test is to
+# support latest Rust release.
+RUN curl https://sh.rustup.rs -sSf > rustup.sh \
+    && sh rustup.sh -y \
+          --default-toolchain stable \
+          --profile minimal \
+          --no-modify-path \
+    && rm -f rustup.sh \
+    && rustup component add rustfmt \
+    && rustup --version \
+    && cargo -vV \
+    && rustc -vV
+
+# Ubuntu18.04 does not support the Linux kernel that contains BTF section.
+
+WORKDIR /build

--- a/redbpf/Dockerfile.ubuntu20.04
+++ b/redbpf/Dockerfile.ubuntu20.04
@@ -1,0 +1,41 @@
+FROM ubuntu:20.04
+
+ARG TARGETPLATFORM
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get -y install \
+    curl \
+    wget \
+    build-essential \
+    software-properties-common \
+    lsb-release \
+    libelf-dev \
+    linux-headers-generic \
+    && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 13 && rm -f ./llvm.sh
+RUN apt-get -y install \
+    "linux-image-$(ls /lib/modules)" \
+    && apt-get clean -y
+
+RUN ln -s /usr/bin/llvm-config-13 /usr/bin/llvm-config
+RUN llvm-config --version | grep -q '^13'
+
+# Install current stable Rust. The first goal of RedBPF build test is to
+# support latest Rust release.
+RUN curl https://sh.rustup.rs -sSf > rustup.sh \
+    && sh rustup.sh -y \
+          --default-toolchain stable \
+          --profile minimal \
+          --no-modify-path \
+    && rm -f rustup.sh \
+    && rustup component add rustfmt \
+    && rustup --version \
+    && cargo -vV \
+    && rustc -vV
+
+# Ubuntu20.04 does not support the Linux kernel that contains BTF section.
+
+WORKDIR /build

--- a/redbpf/Dockerfile.ubuntu21.04
+++ b/redbpf/Dockerfile.ubuntu21.04
@@ -9,24 +9,25 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 RUN apt-get update \
     && apt-get -y install \
     curl \
+    wget \
     build-essential \
-    libllvm12 \
-    llvm-12-dev \
-    libclang-12-dev \
+    software-properties-common \
+    lsb-release \
     libelf-dev \
-    linux-headers-generic
+    linux-headers-generic \
+    && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 13 && rm -f ./llvm.sh
 RUN apt-get -y install \
     "linux-image-$(ls /lib/modules)" \
     && apt-get clean -y
 
-RUN ln -s /usr/bin/llvm-config-12 /usr/bin/llvm-config
-RUN llvm-config --version | grep -q '^12'
+RUN ln -s /usr/bin/llvm-config-13 /usr/bin/llvm-config
+RUN llvm-config --version | grep -q '^13'
 
-# RedBPF depends on LLVM12 by default and Rust v1.52~v1.55 uses LLVM12
-# cf) RedBPF can rely on LLVM13 and Rust v1.56~ uses LLVM13
+# Install current stable Rust. The first goal of RedBPF build test is to
+# support latest Rust release.
 RUN curl https://sh.rustup.rs -sSf > rustup.sh \
     && sh rustup.sh -y \
-          --default-toolchain 1.55 \
+          --default-toolchain stable \
           --profile minimal \
           --no-modify-path \
     && rm -f rustup.sh \
@@ -37,7 +38,7 @@ RUN curl https://sh.rustup.rs -sSf > rustup.sh \
 
 COPY extract-btf-aarch64.rs .
 
-RUN if [ $TARGETPLATFORM = "linux/arm64" ]; then \
+RUN if [ x$TARGETPLATFORM = x"linux/arm64" ]; then \
       rustc extract-btf-aarch64.rs \
       && gzip -dc /boot/vmlinuz | ./extract-btf-aarch64 /dev/stdin /boot/vmlinux-btf; \
     else \


### PR DESCRIPTION
@rsdy 

- As discussed in #6, change fixed rust version to current stable release.
- And Ubuntu 20.04 LTS, 18.04 LTS are added.