### PR TITLE
Add gentoo build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -194,6 +194,39 @@ jobs:
           docker push ${{ steps.x86_64-alpine315.outputs.image_id }}
           docker push ${{ steps.x86_64-archlinux.outputs.image_id }}
 
+  # NOTE: A redbpf-build-aarch64-gentoo-and-push job can not be supported since
+  # it takes over 6 hours to finish building the docker image
+
+  redbpf-build-x86_64-gentoo-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up version information
+        run: |
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          [ "$VERSION" == "$MAIN_BRANCH" ] && VERSION=latest
+          echo "version=$VERSION" >> $GITHUB_ENV
+      -
+        name: Build x86_64 gentoo for RedBPF
+        id: x86_64-gentoo
+        run: |
+          VERSION=${{ env.version }}-x86_64-gentoo
+          docker build -f redbpf/Dockerfile.gentoo \
+          -t $REDBPF_IMAGE_NAME:$VERSION ./redbpf
+          echo "::set-output name=image_id::$REDBPF_IMAGE_NAME:$VERSION"
+      -
+        name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      -
+        name: Push image
+        if: github.event_name == 'push'
+        run: |
+          docker push ${{ steps.x86_64-gentoo.outputs.image_id }}
+
   build-and-push:
     runs-on: ubuntu-latest
     steps:

--- a/redbpf/Dockerfile.gentoo
+++ b/redbpf/Dockerfile.gentoo
@@ -1,0 +1,31 @@
+FROM gentoo/stage3
+ARG TARGETPLATFORM
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:/usr/lib/llvm/13/bin:$PATH
+
+# could not find prebuilt llvm and clang in Feb 2022.
+RUN emerge --sync \
+    && emerge sys-devel/llvm \
+    sys-devel/clang \
+    virtual/libelf \
+    sys-kernel/gentoo-kernel-bin
+
+RUN llvm-config --version | grep -q '^13'
+
+# Install current stable Rust. The first goal of RedBPF build test is to
+# support latest Rust release.
+RUN curl https://sh.rustup.rs -sSf > rustup.sh \
+    && sh rustup.sh -y \
+          --default-toolchain stable \
+          --profile minimal \
+          --no-modify-path \
+    && rm -f rustup.sh \
+    && rustup component add rustfmt \
+    && rustup --version \
+    && cargo -vV \
+    && rustc -vV
+
+# gentoo prebuilt kernel does not contain BTF section
+
+WORKDIR /build


### PR DESCRIPTION
Add RedBPF build image for gentoo linux.
I guess it takes long time to complete building docker image of gentoo since it is required compiling the LLVM and clang.