### PR TITLE
Fix CI and Upgrade to llvm14

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,6 +11,9 @@ on:
 
   # Run tests for any PRs.
   pull_request:
+    types:
+      - opened
+      - edited
 
 env:
   REDBPF_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/redbpf-build
@@ -41,6 +44,12 @@ jobs:
           echo "Status:    ${{ steps.buildx.outputs.status }}"
           echo "Flags:     ${{ steps.buildx.outputs.flags }}"
           echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
+            
+      -
+        name: Set image name lowercase
+        run: |
+          echo "REDBPF_IMAGE_NAME=${REDBPF_IMAGE_NAME,,}" >>${GITHUB_ENV}
+
       -
         name: Set up version information
         run: |
@@ -107,6 +116,11 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v2
+      -
+        name: Set image name lowercase
+        run: |
+          echo "REDBPF_IMAGE_NAME=${REDBPF_IMAGE_NAME,,}" >>${GITHUB_ENV}
+      
       -
         name: Set up version information
         run: |
@@ -186,6 +200,10 @@ jobs:
         name: Checkout
         uses: actions/checkout@v2
       -
+        name: Set image name lowercase
+        run: |
+          echo "REDBPF_IMAGE_NAME=${REDBPF_IMAGE_NAME,,}" >>${GITHUB_ENV}
+      -
         name: Set up version information
         run: |
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
@@ -214,6 +232,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set image name lowercase
+        run: |
+          echo "IMAGE_NAME=${IMAGE_NAME,,}" >>${GITHUB_ENV}
+
       - name: Set up version information
         run: |
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
@@ -221,12 +243,12 @@ jobs:
           [ "$VERSION" == "$MAIN_BRANCH" ] && VERSION=latest
           echo "version=$VERSION" >> $GITHUB_ENV
 
-      - name: Build Ubuntu 21.04
-        id: ubuntu2104
+      - name: Build Ubuntu 22.04
+        id: ubuntu2204
         run: |
-          VERSION=${{ env.version }}-ubuntu-21.04
+          VERSION=${{ env.version }}-ubuntu-22.04
           docker build --no-cache \
-                       -f Dockerfile.21.04 \
+                       -f Dockerfile.22.04 \
                        -t $IMAGE_NAME:$VERSION \
                        .
           echo "::set-output name=image_id::$IMAGE_NAME:$VERSION"
@@ -251,22 +273,22 @@ jobs:
                        .
           echo "::set-output name=image_id::$IMAGE_NAME:$VERSION"
 
-      - name: Build Fedora 34
-        id: fedora34
+      - name: Build Fedora 36
+        id: fedora36
         run: |
-          VERSION=${{ env.version }}-fedora-34
+          VERSION=${{ env.version }}-fedora36
           docker build --no-cache \
-                       -f Dockerfile.fedora-34 \
+                       -f Dockerfile.fedora36 \
                        -t $IMAGE_NAME:$VERSION \
                        .
           echo "::set-output name=image_id::$IMAGE_NAME:$VERSION"
 
-      - name: Build Alpine 3.14
-        id: alpine314
+      - name: Build Alpine Edge
+        id: alpine-edge
         run: |
-          VERSION=${{ env.version }}-alpine
+          VERSION=${{ env.version }}-alpine-edge
           docker build --no-cache \
-                       -f Dockerfile.alpine \
+                       -f Dockerfile.alpine-edge \
                        -t $IMAGE_NAME:$VERSION \
                        .
           echo "::set-output name=image_id::$IMAGE_NAME:$VERSION"
@@ -277,8 +299,8 @@ jobs:
       - name: Push image
         if: github.event_name == 'push'
         run: |
-          docker push ${{ steps.ubuntu2104.outputs.image_id }}
+          docker push ${{ steps.ubuntu2204.outputs.image_id }}
           docker push ${{ steps.ubuntu2004.outputs.image_id }}
           docker push ${{ steps.ubuntu1804.outputs.image_id }}
-          docker push ${{ steps.fedora34.outputs.image_id }}
-          docker push ${{ steps.alpine314.outputs.image_id }}
+          docker push ${{ steps.fedora36.outputs.image_id }}
+          docker push ${{ steps.alpine-edge.outputs.image_id }}

--- a/Dockerfile.18.04
+++ b/Dockerfile.18.04
@@ -7,19 +7,46 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
-    && apt-get -y install curl wget lsb-release wget software-properties-common debhelper cmake \
-       libelf-dev bison flex libedit-dev python python-netaddr \
-       python-pyroute2 luajit libluajit-5.1-dev arping iperf netperf ethtool \
-       devscripts zlib1g-dev libfl-dev \
-       pkg-config libssl-dev \
-       git \
-       musl musl-tools musl-dev \
-       capnproto \
-       linux-base libkmod2 kmod \
-    && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 12 && rm -f ./llvm.sh \
-    && apt-get update && apt-get -y install llvm libllvm12 llvm-12-dev libclang-12-dev clang-format-12 clang \
+    && apt-get -y install \
+        curl \
+        wget \
+        lsb-release \
+        software-properties-common \
+        debhelper \
+        cmake \
+        libelf-dev \
+        bison \
+        flex \
+        libedit-dev \
+        python \
+        python-netaddr \
+        python-pyroute2 \
+        luajit \
+        libluajit-5.1-dev \
+        arping \
+        iperf \
+        netperf \
+        ethtool \
+        devscripts \
+        zlib1g-dev \
+        libfl-dev \
+        pkg-config \
+        libssl-dev \
+        git \
+        musl \
+        musl-tools \
+        musl-dev \
+        capnproto \
+        linux-base \
+        libkmod2 \
+        kmod \
+    && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+    && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 14 && rm -f ./llvm.sh \
+    && apt-get update && apt-get -y install llvm libllvm14 llvm-14-dev libclang-14-dev clang-format-14 clang \
     && apt-get clean -y
 
+RUN ln -sf /usr/bin/llvm-config-14 /usr/bin/llvm-config
+RUN llvm-config --version | grep -q '^14'
 
 # Install kernel v4.19 to check the oldest supported kernel
 WORKDIR /tmp/kernel

--- a/Dockerfile.20.04
+++ b/Dockerfile.20.04
@@ -7,18 +7,43 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
-    && apt-get -y install curl wget lsb-release wget software-properties-common \
-       debhelper cmake llvm libllvm12 llvm-12-dev libclang-12-dev \
-       libelf-dev bison flex libedit-dev clang-format-12 python python-netaddr \
-       luajit libluajit-5.1-dev arping iperf netperf ethtool \
-       devscripts zlib1g-dev libfl-dev \
-       pkg-config libssl-dev \
-       git \
-       clang \
-       musl musl-tools musl-dev \
-       capnproto \
-       linux-headers-generic \
+    && apt-get -y install \
+        curl \
+        wget \
+        lsb-release \
+        software-properties-common \
+        debhelper \
+        cmake \
+        libelf-dev \
+        bison \
+        flex \
+        libedit-dev \
+        python-is-python3 \
+        python3-netaddr \
+        python3-pyroute2 \
+        luajit \
+        libluajit-5.1-dev \
+        arping \
+        iperf \
+        netperf \
+        ethtool \
+        devscripts \
+        zlib1g-dev \
+        libfl-dev \
+        pkg-config \
+        libssl-dev \
+        git \
+        musl \
+        musl-tools \
+        musl-dev \
+        capnproto \
+        linux-headers-generic \
+    && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 14 && rm -f ./llvm.sh \
+    && apt-get update && apt-get -y install llvm libllvm14 llvm-14-dev libclang-14-dev clang-format-14 clang \
     && apt-get clean -y
+
+RUN ln -sf /usr/bin/llvm-config-14 /usr/bin/llvm-config
+RUN llvm-config --version | grep -q '^14'
 
 RUN curl https://sh.rustup.rs -sSf > rustup.sh \
     && sh rustup.sh -y \

--- a/Dockerfile.22.04
+++ b/Dockerfile.22.04
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:22.04
 
 ARG openssl_arch=linux-x86_64
 ENV RUSTUP_HOME=/usr/local/rustup \
@@ -7,18 +7,47 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
-    && apt-get -y install curl wget lsb-release wget software-properties-common \
-       debhelper cmake llvm libllvm12 llvm-12-dev libclang-12-dev \
-       libelf-dev bison flex libedit-dev clang-format-12 python python3-netaddr \
-       luajit libluajit-5.1-dev arping iperf netperf ethtool \
-       devscripts zlib1g-dev libfl-dev \
-       pkg-config libssl-dev \
-       git \
-       clang \
-       musl musl-tools musl-dev \
-       capnproto \
-       linux-headers-generic \
+    && apt-get -y install \
+        curl \
+        wget \
+        lsb-release \
+        software-properties-common \
+        debhelper \
+        cmake \
+        llvm \
+        libllvm14 \
+        llvm-14-dev \
+        libclang-14-dev \
+        libelf-dev \
+        bison \
+        flex \
+        libedit-dev \
+        clang-format-14 \
+        python-is-python3 \
+        python3-netaddr \
+        luajit \
+        libluajit-5.1-dev \
+        arping \
+        iperf \
+        netperf \
+        ethtool \
+        devscripts \
+        zlib1g-dev \
+        libfl-dev \
+        pkg-config \
+        libssl-dev \
+        git \
+        clang \
+        musl \
+        musl-tools\
+        musl-dev \
+        capnproto \
+        linux-headers-generic \
     && apt-get clean -y
+
+RUN ln -sf /usr/bin/llvm-config-14 /usr/bin/llvm-config
+RUN llvm-config --version | grep -q '^14'
+
 RUN apt-get -y install "linux-image-$(ls /lib/modules)"
 
 RUN curl https://sh.rustup.rs -sSf > rustup.sh \

--- a/Dockerfile.alpine-edge
+++ b/Dockerfile.alpine-edge
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:edge
 
 ARG openssl_arch=linux-x86_64
 ENV RUSTUP_HOME=/usr/local/rustup \
@@ -6,10 +6,33 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     PATH=/usr/local/cargo/bin:$PATH \
     DEBIAN_FRONTEND=noninteractive
 
-RUN apk add --no-cache curl wget linux-headers make perl makedepend \
-    grep coreutils binutils linux-lts-dev linux-lts libxml2-dev gcc libc-dev \
-    clang-libs llvm11 llvm11-libs llvm11-dev llvm11-static g++ \
-    openssl openssl-dev openssl-libs-static
+RUN apk add --no-cache \
+    curl \
+    wget \
+    linux-headers \
+    make \
+    perl \
+    makedepend \
+    grep \
+    coreutils \
+    binutils \
+    linux-lts-dev \
+    linux-lts \
+    libxml2-dev \
+    gcc \
+    libc-dev \
+    clang-libs \
+    llvm14 \
+    llvm14-libs \
+    llvm14-dev \
+    llvm14-static \
+    g++ \
+    openssl \
+    openssl-dev \
+    openssl-libs-static
+
+RUN ln -sf /usr/lib/llvm14/bin/llvm-config /usr/bin/llvm-config
+RUN llvm-config --version | grep -q '^14'
 
 RUN curl https://sh.rustup.rs -sSf > rustup.sh \
     && sh rustup.sh -y \

--- a/Dockerfile.fedora36
+++ b/Dockerfile.fedora36
@@ -1,4 +1,4 @@
-FROM fedora:34
+FROM fedora:36
 
 ARG openssl_arch=linux-x86_64
 ENV RUSTUP_HOME=/usr/local/rustup \
@@ -6,21 +6,34 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     PATH=/usr/local/cargo/bin:$PATH \
     DEBIAN_FRONTEND=noninteractive
 
-RUN dnf install -y clang-12.0.0 \
-	llvm-12.0.0 \
-	llvm-libs-12.0.0 \
-	llvm-devel-12.0.0 \
-	llvm-static-12.0.0 \
-	kernel \
-	kernel-devel \
-	elfutils-libelf-devel \
-	ca-certificates \
-	musl-devel musl-clang musl-libc musl-libc-static musl-gcc \
-	openssl-devel perl-podlators perl-File-Compare \
-	capnproto \
-	dnf-utils \
-	git \
-	make makedepend zstd bzip2
+RUN echo "max_parallel_download=20" >> /etc/dnf/dnf.conf \
+    && echo "fastestmirror=True" >> /etc/dnf/dnf.conf \
+    && dnf install -y clang-14.0.0 \
+        llvm-14.0.0 \
+        llvm-libs-14.0.0 \
+        llvm-devel-14.0.0 \
+        llvm-static-14.0.0 \
+        kernel \
+        kernel-devel \
+        elfutils-libelf-devel \
+        ca-certificates \
+        musl-devel \
+        musl-clang \
+        musl-libc \
+        musl-libc-static \
+        musl-gcc \
+        openssl-devel \
+        perl-podlators \
+        perl-File-Compare \
+        capnproto \
+        dnf-utils \
+        git \
+	    make \
+        makedepend \
+        zstd \
+        bzip2
+
+RUN llvm-config --version | grep -q '^14'
 
 RUN curl https://sh.rustup.rs -sSf > rustup.sh \
     && sh rustup.sh -y \

--- a/redbpf/Dockerfile.alpine-edge
+++ b/redbpf/Dockerfile.alpine-edge
@@ -15,12 +15,13 @@ RUN apk add --no-cache \
     linux-lts-dev \
     linux-lts \
     clang-libs \
-    llvm13 \
-    llvm13-libs \
-    llvm13-dev \
-    llvm13-static
+    llvm14 \
+    llvm14-libs \
+    llvm14-dev \
+    llvm14-static
 
-RUN llvm-config --version | grep -q '^13'
+RUN ln -sf /usr/lib/llvm14/bin/llvm-config /usr/bin/llvm-config
+RUN llvm-config --version | grep -q '^14'
 
 RUN curl https://sh.rustup.rs -sSf > rustup.sh \
     && sh rustup.sh -y \

--- a/redbpf/Dockerfile.archlinux
+++ b/redbpf/Dockerfile.archlinux
@@ -6,16 +6,16 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 
 RUN pacman --noconfirm -Syu \
     && pacman -S --noconfirm \
-    pkg-config \
-    llvm \
-    llvm-libs \
-    libffi \
-    clang \
-    make \
-    linux-headers \
-    linux
+        pkg-config \
+        llvm \
+        llvm-libs \
+        libffi \
+        clang \
+        make \
+        linux-headers \
+        linux
 
-RUN llvm-config --version | grep -q '^13'
+RUN llvm-config --version | grep -q '^14'
 
 # Install current stable Rust. The first goal of RedBPF build test is to
 # support latest Rust release.

--- a/redbpf/Dockerfile.debian11
+++ b/redbpf/Dockerfile.debian11
@@ -8,20 +8,20 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 
 RUN apt-get update \
     && apt-get -y install \
-    pkg-config \
-    curl \
-    wget \
-    lsb-release \
-    libelf-dev \
-    build-essential \
-    linux-headers-generic \
-    software-properties-common \
-    gnupg2 \
+        pkg-config \
+        curl \
+        wget \
+        lsb-release \
+        libelf-dev \
+        build-essential \
+        linux-headers-generic \
+        software-properties-common \
+        gnupg2 \
     && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 14 && rm -f ./llvm.sh \
     && apt-get -y install "linux-image-$(ls /lib/modules)" \
     && apt-get clean -y
 
-RUN ln -s /usr/bin/llvm-config-14 /usr/bin/llvm-config
+RUN ln -sf /usr/bin/llvm-config-14 /usr/bin/llvm-config
 RUN llvm-config --version | grep -q '^14'
 
 # Install current stable Rust. The first goal of RedBPF build test is to
@@ -47,6 +47,7 @@ RUN if [ x$TARGETPLATFORM = x"linux/arm64" ]; then \
       && sh extract-vmlinux /boot/vmlinuz-* > /boot/vmlinux \
       && rm -f extract-vmlinux; \
     fi
+    
 RUN rm -f extract-btf-aarch64.rs
 
 WORKDIR /build

--- a/redbpf/Dockerfile.fedora36
+++ b/redbpf/Dockerfile.fedora36
@@ -5,18 +5,21 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH
 
-RUN dnf install -y \
-    pkg-config \
-    clang \
-	llvm \
-	llvm-libs \
-	llvm-devel \
-	llvm-static \
-	kernel \
-	kernel-devel \
-	elfutils-libelf-devel \
-	make \
-    zstd
+# Adding these 2 dnf.conf settings improved install times.
+RUN echo "max_parallel_download=20" >> /etc/dnf/dnf.conf \
+    && echo "fastestmirror=True" >> /etc/dnf/dnf.conf \
+    && dnf install -y \
+        pkg-config \
+        clang \
+        llvm \
+        llvm-libs \
+        llvm-devel \
+        llvm-static \
+        kernel \
+        kernel-devel \
+        elfutils-libelf-devel \
+        make \
+        zstd
 
 RUN llvm-config --version | grep -q '^14'
 

--- a/redbpf/Dockerfile.gentoo
+++ b/redbpf/Dockerfile.gentoo
@@ -4,14 +4,19 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:/usr/lib/llvm/13/bin:$PATH
 
+
+RUN emerge-webrsync
+RUN emerge app-portage/mirrorselect
+RUN mirrorselect -s3 -b10 -D -c USA
 # could not find prebuilt llvm and clang in Feb 2022.
 RUN emerge --sync \
     && emerge sys-devel/llvm \
-    sys-devel/clang \
-    virtual/libelf \
-    sys-kernel/gentoo-kernel-bin
+        sys-devel/clang \
+        virtual/libelf \
+        sys-kernel/gentoo-kernel-bin
 
-RUN llvm-config --version | grep -q '^13'
+RUN ln -sf /usr/lib/llvm/14/bin/llvm-config /usr/bin/llvm-config
+RUN llvm-config --version | grep -q '^14'
 
 # Install current stable Rust. The first goal of RedBPF build test is to
 # support latest Rust release.

--- a/redbpf/Dockerfile.ubuntu20.04
+++ b/redbpf/Dockerfile.ubuntu20.04
@@ -8,20 +8,20 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 
 RUN apt-get update \
     && apt-get -y install \
-    pkg-config \
-    curl \
-    wget \
-    build-essential \
-    software-properties-common \
-    lsb-release \
-    libelf-dev \
-    linux-headers-generic \
+        pkg-config \
+        curl \
+        wget \
+        build-essential \
+        software-properties-common \
+        lsb-release \
+        libelf-dev \
+        linux-headers-generic \
     && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 14 && rm -f ./llvm.sh
 RUN apt-get -y install \
     "linux-image-$(ls /lib/modules)" \
     && apt-get clean -y
 
-RUN ln -s /usr/bin/llvm-config-14 /usr/bin/llvm-config
+RUN ln -sf /usr/bin/llvm-config-14 /usr/bin/llvm-config
 RUN llvm-config --version | grep -q '^14'
 
 # Install current stable Rust. The first goal of RedBPF build test is to

--- a/redbpf/Dockerfile.ubuntu22.04
+++ b/redbpf/Dockerfile.ubuntu22.04
@@ -8,20 +8,20 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 
 RUN apt-get update \
     && apt-get -y install \
-    pkg-config \
-    curl \
-    wget \
-    build-essential \
-    software-properties-common \
-    lsb-release \
-    libelf-dev \
-    linux-headers-generic \
+        pkg-config \
+        curl \
+        wget \
+        build-essential \
+        software-properties-common \
+        lsb-release \
+        libelf-dev \
+        linux-headers-generic \
     && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 14 && rm -f ./llvm.sh
 RUN apt-get -y install \
     "linux-image-$(ls /lib/modules)" \
     && apt-get clean -y
 
-RUN ln -s /usr/bin/llvm-config-14 /usr/bin/llvm-config
+RUN ln -sf /usr/bin/llvm-config-14 /usr/bin/llvm-config
 RUN llvm-config --version | grep -q '^14'
 
 # Install current stable Rust. The first goal of RedBPF build test is to


### PR DESCRIPTION
This PR adds the changes required to make all the build images CI workflows pass in terms of building the images, and verifying they are all upgraded to LLVM 14. A successful run can be seen [here](https://github.com/DerekStrickland/build-images/actions/runs/3242932287). The PR also includes some small quality of life improvements in terms of code formatting.

These changes were made to support [RedBPF #312](https://github.com/foniod/redbpf/issues/312). The specific changes include:

- I added `Set image name lowercase` steps in the publish workflow to lowercase `REDBPF_IMAGE_NAME`. This was required so that someone like myself who forks and has uppercase letters in their GitHub username can produce docker images with a valid name.
- Updated Ubuntu 21.04 to 22.04 as 21.04 is now EOL.
- Updated Fedora 34 to 36
- Updated Alpine 3.14 to Alpine Edge
- Updated multiple `apt-get install` blocks to have one package per line to make visual comparison across files easier
- In multiple cases I updated the installation script to reference `llvm14`
- In multiple cases I added a symlink from the distro specific location of `llvm-config-14` to `/usr/bin/llvm-config`
- In multiple cases I updated the `llvm-config --version` check script from 13 to 14
- Added `max_parallel_download=20` and `fastestmirror=True` to the Fedora `dnf.conf` to speed up image build times
- Added `emerge-websync` to Gentoo to overcome spurious network errors when building
- Added `emerge app-portage/mirrorselect` and `mirrorselect -s3 -b10 -D -c USA` to Gentoo to hopefully speed up build times. I am not sure this is necessary with `emerge-webrsync` but my Gentoo was non-existent prior to this PR 😺

What I did not do was devise a way to parameterize the llvm version, which seems like a good idea in terms of future maintenance. I can do that in a subsequent PR or this one if desired.