### PR TITLE
update from bindgen to bindgen-cli crate

### DIFF
--- a/Dockerfile.18.04
+++ b/Dockerfile.18.04
@@ -70,7 +70,7 @@ RUN curl https://sh.rustup.rs -sSf > rustup.sh \
     && rustup --version \
     && cargo --version \
     && rustc --version \
-    && cargo install bindgen \
+    && cargo install bindgen-cli \
     && rm -f rustup.sh
 
 RUN echo "Building OpenSSL" \

--- a/Dockerfile.20.04
+++ b/Dockerfile.20.04
@@ -56,7 +56,7 @@ RUN curl https://sh.rustup.rs -sSf > rustup.sh \
     && rustup --version \
     && cargo --version \
     && rustc --version \
-    && cargo install bindgen \
+    && cargo install bindgen-cli \
     && rm -f rustup.sh
 
 RUN echo "Building OpenSSL" \

--- a/Dockerfile.22.04
+++ b/Dockerfile.22.04
@@ -61,7 +61,7 @@ RUN curl https://sh.rustup.rs -sSf > rustup.sh \
     && rustup --version \
     && cargo --version \
     && rustc --version \
-    && cargo install bindgen \
+    && cargo install bindgen-cli \
     && rm -f rustup.sh
 
 RUN echo "Building OpenSSL" \

--- a/Dockerfile.alpine-edge
+++ b/Dockerfile.alpine-edge
@@ -46,7 +46,7 @@ RUN curl https://sh.rustup.rs -sSf > rustup.sh \
     && cargo --version \
     && rustc --version \
     && rustup install 1.51 \
-    && cargo install bindgen
+    && cargo install bindgen-cli
 
 ENV OPENSSL_STATIC=1
 

--- a/Dockerfile.fedora36
+++ b/Dockerfile.fedora36
@@ -46,7 +46,7 @@ RUN curl https://sh.rustup.rs -sSf > rustup.sh \
     && rustup --version \
     && cargo --version \
     && rustc --version \
-    && cargo install bindgen
+    && cargo install bindgen-cli
 
 RUN echo "Building OpenSSL" \
     && VERS=1.0.2p \


### PR DESCRIPTION
Signed-off-by: DerekStrickland <derek.strickland@gmail.com>

Just as we were reviewing this PR bindgen published a new release which required this change to the cargo install commands.